### PR TITLE
fix: fix keys not in spec

### DIFF
--- a/python.json
+++ b/python.json
@@ -22,11 +22,21 @@
     },
     {
       "matchDatasources": ["pypi", "conda"],
-      "allowedUpdateTypes": ["patch"]
+      "major": {
+        "enabled": false
+      },
+      "minor": {
+        "enabled": false
+      }
     },
     {
       "matchDepTypes": ["dependency-groups"],
-      "allowedUpdateTypes": ["patch", "minor", "major"],
+      "major": {
+        "enabled": true
+      },
+      "minor": {
+        "enabled": true
+      },
       "patch": {
         "automerge": true
       }


### PR DESCRIPTION
## 関連するIssue

## 変更内容

- `allowedUpdateTypes`はDocsで確認できなかったので、各Typeごとに有効・無効を指定するように変更

## 備考